### PR TITLE
Fix usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ connected watch -- say "Power cable disconnected."
 or use `--command (-c)`
 
 ``` console
-$ connected watch -c "osascript -e "set Volume 10"; say -v Alex "Power cable disconnected."
+$ connected watch -c 'osascript -e "set Volume 10"; say -v Alex "Power cable disconnected."'
 ```
 
 **Watch Wi-Fi connection:**


### PR DESCRIPTION
Thanks for an interesting CLI!

Fixed usage as below:

## Before

```console
$ connected watch -c "osascript -e "set Volume 10"; say -v Alex "Power cable disconnected."
dquote> 
```

## After

```console
$ connected watch -c 'osascript -e "set Volume 10"; say -v Alex "Power cable disconnected."'
Power cable is connected
Start watching connection (Power cable).
```